### PR TITLE
boards: arm: max32655evkit: Add JLink support

### DIFF
--- a/boards/arm/max32655evkit/board.cmake
+++ b/boards/arm/max32655evkit/board.cmake
@@ -4,6 +4,12 @@
 if(CONFIG_BOARD_MAX32655EVKIT)
 board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
 board_runner_args(openocd --cmd-pre-init "source [find target/max32655.cfg]")
+board_runner_args(jlink "--device=MAX32655" "--reset-after-load")
 endif()
 
+# Make OpenOCD the default runner
+set_ifndef(BOARD_DEBUG_RUNNER openocd)
+set_ifndef(BOARD_FLASH_RUNNER openocd)
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Adds JLink as an optional runner, which can be selected with `west` via `--runner jlink`.

OpenOCD is left as the default runner for debug and flash.