### PR TITLE
Add MAX32662, MAX32690 clock calibration API

### DIFF
--- a/drivers/clock_control/clock_control_max32.c
+++ b/drivers/clock_control/clock_control_max32.c
@@ -103,6 +103,18 @@ static DEVICE_API(clock_control, max32_clkctrl_api) = {
 	.get_rate = api_get_rate,
 };
 
+int max32_clock_calibrate_ipo()
+{
+	int ret = Wrap_MXC_SYS_ClockCalibrate(MXC_SYS_CLOCK_IPO);
+	if(ret == E_NO_ERROR)
+		return 0;
+	if(ret == E_NOT_SUPPORTED) // Only MAX32662 and MAX32690 implement clock calibration
+		return -ENOSYS;
+	if(ret == E_BAD_PARAM)
+		return -EINVAL;
+	return -1;
+}
+
 static void setup_fixed_clocks(void)
 {
 #if DT_NODE_HAS_COMPAT(DT_NODELABEL(clk_extclk), fixed_clock)

--- a/include/zephyr/drivers/clock_control/adi_max32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/adi_max32_clock_control.h
@@ -109,4 +109,16 @@ struct max32_perclk {
 	 : (clk_src) == ADI_MAX32_PRPH_CLK_SRC_EBO       ? ADI_MAX32_CLK_EBO_FREQ                  \
 							 : 0)
 
+/**
+* @brief Calibrates IPO with respect to external ERTCO 32.768KHz oscillator
+*
+* @note Only implemented for MAX32662 and MAX32690
+*
+* @return 0 if successful
+* @return -ENOSYS if IPO calibration is not implemented on the current target
+* @return -EINVAL if hal_adi implementation returns E_BAD_PARAM
+* @return -1 if another error occured
+*/
+int max32_clock_calibrate_ipo(void);
+
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_ADI_MAX32_CLOCK_CONTROL_H_ */

--- a/west.yml
+++ b/west.yml
@@ -144,7 +144,7 @@ manifest:
       groups:
         - fs
     - name: hal_adi
-      revision: d2886b8b8e3f71058a221f6351a8200fba80f229
+      revision: 8eeaf46b57516ba56d24b14296eb6d8399af4c8d
       path: modules/hal/adi
       groups:
         - hal


### PR DESCRIPTION
Create a function `max32_clock_calibrate_ipo()` that runs IPO calibration based on an external 32768 Hz oscillator, as described in [MAX32662 UG] section 4.2.1.1 and [MAX32690 UG] section 4.1.1.1

[MAX32690 UG]: https://www.analog.com/media/en/technical-documentation/user-guides/ug7618.pdf
[MAX32662 UG]: https://www.analog.com/media/en/technical-documentation/user-guides/max32662-ug-7640.pdf

Dependencies:
- [ ] https://github.com/analogdevicesinc/msdk/pull/1427 which implements the actual calibration logic

From checking other vendors' code, there seems to be no clear convention on what to do with nonstandard APIs, so I welcome your input on whether it makes sense to have this function where it is right now, or whether I should move it somewhere else.

## Example usage
```c
#include <zephyr/drivers/clock_control/adi_max32_clock_control.h>

int main()
{
    int ret = 0;

    printk("Calibrating IPO with respect to ERTCO");
    ret = max32_clock_calibrate_ipo();
    if(ret < 0) {
        printk("Could not calibrate IPO: %d", ret);
    } else {
        printk("Success!");
    }

    return ret;
}
```

## Use-case

As described in the MSDK PR linked above, I would need this for a CAN bus application. Devices on a CAN bus have some flexibility when it comes to clock frequency differences, but without clock calibration, MAX32662 has too much variation and CAN devices error-out because of it. Running clock calibration brings all devices' clocks considerably closer to their ideal values and fixes the observed communication errors.
